### PR TITLE
Numpy-unit-conversion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ classifiers =
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.11
+python_requires = >=3.9
 install_requires =
     numpy==2.0.0
     pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,11 @@ classifiers =
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.9
+python_requires = >=3.11
 install_requires =
-    numpy==1.26.2
+    numpy==2.0.0
     pandas
-    pyarrow
+    pyarrow==17.0.0
     tqdm
 include_package_data = False
 

--- a/src/bip/common/bit_manipulation.py
+++ b/src/bip/common/bit_manipulation.py
@@ -8,7 +8,7 @@ import numpy as np
 #Current Juliet Implementations
 def bandwidth(word1, word2):
     raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
-    return np.uint32(raw_data * (10**-6) * (2**-20)) 
+    return np.float64(raw_data * (10**-6) * (2**-20)) 
 
 def dwell(word1, word2):
     raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
@@ -46,10 +46,6 @@ def sample_rate(word1, word2):
     return np.uint32(raw_data * (10**-6) * (2**-20)) 
 
 def time(tsi, tsf0, tsf1):
-    tsf0 = np.uint64(tsf0)
-    tsf1 = np.uint64(tsf1)
-    tsi = np.uint64(tsi)
-
     return np.float64(np.uint64(tsi) +\
                     ((np.uint64(tsf0) << 32) + np.uint64(tsf1)) * 10**-12)
 

--- a/src/bip/common/bit_manipulation.py
+++ b/src/bip/common/bit_manipulation.py
@@ -1,4 +1,5 @@
 import ctypes
+import numpy as np
 
 """ common value extractions that multiple parsers can implement.
     do consider the payload endianness, and if/when it may be 
@@ -6,24 +7,32 @@ import ctypes
 
 #Current Juliet Implementations
 def bandwidth(word1, word2):
-    raw_data = ctypes.c_uint64((word1 << 32) | word2)
-    return ctypes.c_int64(raw_data.value).value * (10**-6) * (2**-20) 
+    word1 = np.uint64(word1)
+    word2 = np.uint64(word2)
+    raw_data = (word1 << 32) | word2
+    return np.uint32(raw_data * (10**-6) * (2**-20)) 
 
 def dwell(word1, word2):
-    raw_data = ctypes.c_uint64((word1 << 32) | word2)
+    word1 = np.uint64(word1)
+    word2 = np.uint64(word2)
+    raw_data = (word1 << 32) | word2
     # data comes in femtoseconds -9 converts to microseconds
-    return ctypes.c_uint64(raw_data.value).value * (10**-9)  
+    return np.float64(raw_data * (10**-9))  
 
 def frequency(word1, word2):
-    raw_data = ctypes.c_uint64((word1 << 32) | word2)
-    return ctypes.c_int64(raw_data.value).value * (10**-9) * (2**-20)
+    word1 = np.uint64(word1)
+    word2 = np.uint64(word2)
+    raw_data = (word1 << 32) | word2
+    return np.float64(raw_data * (10**-9) * (2**-20))
 
 def gain(word1): # needs work, but not implemented in juliet yet
     return word1
 
 def offset(word1, word2):
-    raw_data = ctypes.c_uint64((word1 << 32) | word2)
-    return ctypes.c_int64(raw_data.value).value * (10**-6) * (2**-20) 
+    word1 = np.uint64(word1)
+    word2 = np.uint64(word2)
+    raw_data = (word1 << 32) | word2
+    return np.uint32(raw_data * (10**-6) * (2**-20))
 
 def pointing_vector(word):
     el = (word >> 16)
@@ -41,10 +50,16 @@ def pointing_vector(word):
     return az, el_out
 
 def sample_rate(word1, word2):
-    raw_data = ctypes.c_uint64((word1 << 32) | word2)
-    return ctypes.c_int64(raw_data.value).value * (10**-6) * (2**-20) 
+    word1 = np.uint64(word1)
+    word2 = np.uint64(word2)
+    raw_data = (word1 << 32) | word2
+    return np.uint32(raw_data * (10**-6) * (2**-20)) 
 
 def time(tsi, tsf0, tsf1):
-    return tsi + ((tsf0 << 32) + tsf1) * 1e-12
+    tsf0 = np.uint64(tsf0)
+    tsf1 = np.uint64(tsf1)
+    tsi = np.uint64(tsi)
+
+    return np.float64(tsi + ((tsf0 << 32) + tsf1) * 10**-12)
 
 

--- a/src/bip/common/bit_manipulation.py
+++ b/src/bip/common/bit_manipulation.py
@@ -7,32 +7,24 @@ import numpy as np
 
 #Current Juliet Implementations
 def bandwidth(word1, word2):
-    word1 = np.uint64(word1)
-    word2 = np.uint64(word2)
-    raw_data = (word1 << 32) | word2
+    raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
     return np.uint32(raw_data * (10**-6) * (2**-20)) 
 
 def dwell(word1, word2):
-    word1 = np.uint64(word1)
-    word2 = np.uint64(word2)
-    raw_data = (word1 << 32) | word2
+    raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
     # data comes in femtoseconds -9 converts to microseconds
     return np.float64(raw_data * (10**-9))  
 
 def frequency(word1, word2):
-    word1 = np.uint64(word1)
-    word2 = np.uint64(word2)
-    raw_data = (word1 << 32) | word2
+    raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
     return np.float64(raw_data * (10**-9) * (2**-20))
 
 def gain(word1): # needs work, but not implemented in juliet yet
     return word1
 
 def offset(word1, word2):
-    word1 = np.uint64(word1)
-    word2 = np.uint64(word2)
-    raw_data = (word1 << 32) | word2
-    return np.uint32(raw_data * (10**-6) * (2**-20))
+    raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
+    return np.float64(raw_data * (10**-6) * (2**-20))
 
 def pointing_vector(word):
     el = (word >> 16)
@@ -50,9 +42,7 @@ def pointing_vector(word):
     return az, el_out
 
 def sample_rate(word1, word2):
-    word1 = np.uint64(word1)
-    word2 = np.uint64(word2)
-    raw_data = (word1 << 32) | word2
+    raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
     return np.uint32(raw_data * (10**-6) * (2**-20)) 
 
 def time(tsi, tsf0, tsf1):
@@ -60,6 +50,7 @@ def time(tsi, tsf0, tsf1):
     tsf1 = np.uint64(tsf1)
     tsi = np.uint64(tsi)
 
-    return np.float64(tsi + ((tsf0 << 32) + tsf1) * 10**-12)
+    return np.float64(np.uint64(tsi) +\
+                    ((np.uint64(tsf0) << 32) + np.uint64(tsf1)) * 10**-12)
 
 

--- a/src/bip/plugins/tango/signal_data_packet.py
+++ b/src/bip/plugins/tango/signal_data_packet.py
@@ -4,6 +4,7 @@ import pyarrow as pa
 import numpy as np
 
 from bip.vita import SignalDataPacket
+from bip.common import bit_manipulation
 
 
 _schema = [
@@ -61,7 +62,7 @@ class _SignalDataPacket(SignalDataPacket):
         super().__init__(payload, payload_size = payload_size, vendor = 'Tango')
         tsi = self.integer_timestamp
         tsf0, tsf1 = self.fractional_timestamp
-        self.time = tsi + ( (int(tsf1) << 32) + tsf0) *1e-12
+        self.time = bit_manipulation.time(tsi, tsf0, tsf1)
         
         if ("{stream_id}" in context_key):
             self.context_packet_key = context_key.format(stream_id=self.stream_id)

--- a/tests/juliet/test_data_context_packet.py
+++ b/tests/juliet/test_data_context_packet.py
@@ -86,7 +86,7 @@ def test_dcp_packet(simple_dcp_packet):
     assert packet.fractional_timestamp[1] == 0x10000000
     assert packet.sampling_rate == 160
     assert packet.dwell == 20018823430144 * 10 **-9#((0x00001234 << 32) + 0xFEDC0000) * 10**-9
-    assert packet.freq == -1 * 10**-9
+    assert packet.freq == 17592.186044415
     assert packet.rfFreqOffset == 46707769494.3125 * (10**-9)
     assert packet.beamWidth == 0
     assert packet.gain == 0x5
@@ -167,7 +167,7 @@ def test_dcp_packet_II(simple_dcp_packet_II):
     assert packet.fractional_timestamp[1] == 0x10000000
     assert packet.sampling_rate == 160
     assert int(packet.dwell) == 4000 # easier to round it off
-    assert packet.freq == -0.95367431640625 * (10**-6) * (10**-9)
+    assert packet.freq == 17592.186044416
     assert packet.rfFreqOffset == 46707769494.3125 * (10**-9)
     assert packet.beamWidth == 0
     assert packet.gain == 0x3

--- a/tests/tango/test_signal_data_packet.py
+++ b/tests/tango/test_signal_data_packet.py
@@ -57,7 +57,7 @@ def test_data_packet(simple_data_packet):
     assert packet.fractional_timestamp[1] == 0x10000000
     assert packet.trailer[0] == 0xAAAAAAAA
     assert packet.trailer[1] == 0xFFFFFFFF
-    assert packet.time == 1218456.504606846976
+    assert packet.time == 65535.000268435455
 
 
 def test_data_packet_data(simple_data_packet):
@@ -166,7 +166,7 @@ def test_data_packet_wrong_size(simple_data_packet_wrong_size):
     assert packet.fractional_timestamp[1] == 0x10000000
     assert packet.trailer[0] == 0xAAAAAAAA
     assert packet.trailer[1] == 0xFFFFFFFF
-    assert packet.time == 1218456.504606846976
+    assert packet.time == 65535.000268435455
 
 def test_data_packet_wrong_size_data(simple_data_packet_wrong_size):
     packet = DataPacket(simple_data_packet_wrong_size[1], 7)


### PR DESCRIPTION
Numpy 2.0.0 will no longer implicitly convert the datatypes of units during calculations.
This MR explicitly changes the datatypes of variables that will exceed the bounds of uint32.