### PR TITLE
Fixing bip to catch tango orphan data

### DIFF
--- a/src/bip/cli.py
+++ b/src/bip/cli.py
@@ -148,6 +148,7 @@ def main():
                 recorder_opts=recorder_opts,
                 data_recorder=data_recorder,
                 clean = args.clean,
+                partitioned = args.partition_data,
                 orphan_context_key=args.partition_orphan_key,
                 context_key_function=lambda k: f"{args.partition_key_prefix}{k}"
                 )

--- a/src/bip/plugins/tango/parser.py
+++ b/src/bip/plugins/tango/parser.py
@@ -64,9 +64,6 @@ class Parser:
         self.clean = False
         if kwargs.get("clean") == True:
             self.clean = True
-        self.partitioned = False
-        if kwargs.get("partitioned") == True:
-            self.partitioned = True
         self._bytes_read = 0
         self._packets_read = 0
         self._frames_read = 0
@@ -418,5 +415,27 @@ class Parser:
                     print(f"{(self.bytes_read / self.EOF) * 100:.2f}% processed")
 
             vita_payload, payload_size = self.read_packet(stream)
+<<<<<<<<< saved version
+            if vita_payload != BAD_PACKET_STATUS_CODE:
+                header = vita.vrt_header(vita_payload)
+                packet = vita.vrt_packet(vita_payload)
+                class_id = packet.class_identifier
+            
+                self.process_packet(header.packet_type, class_id[1], vita_payload, payload_size)
+            
+            self._packets_read += 1
+            self._frames_read += 1
+
+            if progress_bar is not None:
+                progress_bar.update(self.bytes_read - last_read)
+                last_read = self.bytes_read
+            else:
+                if (self.packets_read % 1000 == 0):
+                    print(f"{(self.bytes_read / self.EOF) * 100:.2f}% processed")
+
+            vita_payload, payload_size = self.read_packet(stream)
                 
         self.set_last_context_key()
+=========
+
+>>>>>>>>> local version

--- a/src/bip/plugins/tango/signal_data_packet.py
+++ b/src/bip/plugins/tango/signal_data_packet.py
@@ -114,7 +114,7 @@ class SignalData:
             "tsf1": np.uint32(packet.fractional_timestamp[1]),
             "time": np.float64(packet.time),
 
-            "stream_id": np.uint32(packet.stream_id),
+            "stream_id": np.uint32(packet.stream_identifier),
             "sample_count": np.uint32(packet.sample_count),
             "trailer": np.uint32(packet.trailer),
 

--- a/src/bip/vita/signal_data_packet.py
+++ b/src/bip/vita/signal_data_packet.py
@@ -28,10 +28,6 @@ class SignalDataIndicators:
     def signal_spectrum(self) -> bool:
         return bool(self.value & (1 << 24))
 
-
-
-
-
 class SignalDataPacket(VRTPacket):
     def __init__(self, payload: bytes, **kwargs):
         super().__init__(payload)
@@ -66,14 +62,6 @@ class SignalDataPacket(VRTPacket):
     @property
     def signal_data_indicators(self) -> SignalDataIndicators:
         return SignalDataIndicators(self.words[0])
-
-
-    # signal data packets vita 49.2 properties
-
-    @property
-    def stream_id(self) -> int:
-        return self.words[1]
-
 
     @property
     def class_id_codes(self) -> ClassIdentifier:


### PR DESCRIPTION
The last context_key within a tango bin file data needs to be set to '<format>_LAST' in order for orphan data to find it.
We were not doing that until now.

This ticket will require a RF_data_pipeline ticket to increment Tango's version number and it will require a complete reparse of Tango data to go into effect