### PR TITLE
Dwell recorder output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ cython_debug/
 
 # VSCode
 .vscode
+
+*env*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bip
-version = 0.1.0
+version = 0.2.0
 description = Parse Narrow-scope VITA 49.2 Data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/bip/cli.py
+++ b/src/bip/cli.py
@@ -12,6 +12,7 @@ from bip.parse import parse_bin
 from bip.recorder.parquet.pqwriter import PQWriter
 from bip.recorder.partitioned_parquet.partitioned_pqwriter import PartitionedPQWriter
 from bip.recorder.dwell.dwell_pqwriter import DwellPQWriter
+from bip.recorder.dwell.mikelima_dwell_pqwriter import MikelimaDwellPQWriter
 import bip.plugins
 
 
@@ -139,6 +140,7 @@ def main():
     plugin = plugins[f"bip.plugins.{args.parser}"]
     data_recorder = (
         PartitionedPQWriter if args.partition_data 
+        else MikelimaDwellPQWriter if args.parser == "mikelima" and args.dwell_output
         else DwellPQWriter if args.dwell_output
         else PQWriter
     )

--- a/src/bip/cli.py
+++ b/src/bip/cli.py
@@ -10,7 +10,7 @@ from functools import reduce
 from bip.__version__ import __version__ as version
 from bip.parse import parse_bin
 from bip.recorder.parquet.pqwriter import PQWriter
-from bip.recorder.partitioned_parquet.partitioned_pqwriter import new_partitioned_parquet_writer
+from bip.recorder.partitioned_parquet.partitioned_pqwriter import PartitionedPQWriter
 from bip.recorder.dwell.dwell_pqwriter import DwellPQWriter
 import bip.plugins
 
@@ -136,18 +136,13 @@ def main():
     if args.compression is not None:
         recorder_opts["compression"] = args.compression.upper()
 
-    print(args.dwell_output)
-
     plugin = plugins[f"bip.plugins.{args.parser}"]
     data_recorder = (
-        new_partitioned_parquet_writer(['data_key']) 
-        if args.partition_data 
+        PartitionedPQWriter if args.partition_data 
         else DwellPQWriter if args.dwell_output
         else PQWriter
     )
     
-    print(data_recorder)
-
     log_level = getattr(logging, args.log_level.upper())
     
     try:

--- a/src/bip/cli.py
+++ b/src/bip/cli.py
@@ -11,6 +11,7 @@ from bip.__version__ import __version__ as version
 from bip.parse import parse_bin
 from bip.recorder.parquet.pqwriter import PQWriter
 from bip.recorder.partitioned_parquet.partitioned_pqwriter import new_partitioned_parquet_writer
+from bip.recorder.dwell.dwell_pqwriter import DwellPQWriter
 import bip.plugins
 
 
@@ -95,7 +96,12 @@ def main():
         required=False,
         default="WARNING",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        help="The level of logging you want in the log file.")
+        help="The level of logging you want in the log file."
+    )
+    argparser.add_argument(
+        "--dwell-output",
+        action="store_true"
+    )
 
 
     args = argparser.parse_args()
@@ -130,13 +136,18 @@ def main():
     if args.compression is not None:
         recorder_opts["compression"] = args.compression.upper()
 
+    print(args.dwell_output)
+
     plugin = plugins[f"bip.plugins.{args.parser}"]
     data_recorder = (
         new_partitioned_parquet_writer(['data_key']) 
         if args.partition_data 
+        else DwellPQWriter if args.dwell_output
         else PQWriter
     )
     
+    print(data_recorder)
+
     log_level = getattr(logging, args.log_level.upper())
     
     try:

--- a/src/bip/plugins/juliet/parser.py
+++ b/src/bip/plugins/juliet/parser.py
@@ -100,10 +100,10 @@ class Parser:
             "filename": unknown_packets_filename,
         } | self.unknown_packets_recorder.metadata
 
-        signal_data_filename = f"{SIGNAL_DATA_FILENAME}.{Recorder.extension()}"
+        signal_data_filename = f"{SIGNAL_DATA_FILENAME}.{data_recorder.extension()}"
         self.signal_data = SignalData(
                 output_path / signal_data_filename,
-                Recorder,
+                data_recorder,
                 recorder_opts,
                 batch_size = 1000,
                 clean = self.clean)

--- a/src/bip/plugins/juliet/parser.py
+++ b/src/bip/plugins/juliet/parser.py
@@ -70,6 +70,9 @@ class Parser:
         self._unknown_packets = 0 
         self._closed = False  
 
+        if not data_recorder:
+            data_recorder = Recorder
+
         framing_data_filename = f"{FRAME_DATA_FILENAME}.{Recorder.extension()}"
         self.recorder = Recorder(
                 output_path / framing_data_filename,

--- a/src/bip/plugins/juliet/signal_data_packet.py
+++ b/src/bip/plugins/juliet/signal_data_packet.py
@@ -82,6 +82,7 @@ class SignalData:
             ):
         assert isinstance(packet, _SignalDataPacket)
         header = packet.packet_header
+        stream_id = np.uint32(packet.stream_identifier)
 
         self.recorder.add_record({
             "packet_id": np.uint32(self.packet_id),
@@ -95,7 +96,7 @@ class SignalData:
             "tsf0": np.uint32(packet.fractional_timestamp[0]),
             "tsf1": np.uint32(packet.fractional_timestamp[1]),
             "time": np.float64(packet.time + 1546300800),
-            "stream_id": np.uint32(packet.stream_identifier),
+            "stream_id": stream_id,
             "classId0": np.uint32(packet.classId0),
             "classId1": np.uint32(packet.classId1),
             "sample_count": np.uint32(packet.sample_count),
@@ -104,7 +105,7 @@ class SignalData:
             "packet_index": np.uint32(packet_index),
             "samples_i": packet.data[:,0],
             "samples_q": packet.data[:,1]
-        })
+        }, dwell_key=stream_id)
 
     def process(self,
             payload: bytes,

--- a/src/bip/plugins/mikelima/IQ0_packet_data.py
+++ b/src/bip/plugins/mikelima/IQ0_packet_data.py
@@ -175,5 +175,7 @@ class Process_IQ0_Packet():
         self.AFS_mode = SOM_obj.AFS_mode
         self.SchedNum = SOM_obj.SchedNum
         self.SIinSchedNum = SOM_obj.SIinSchedNum
+
+        self.packet_id += 1
         
         self.__add_record(packet, self.left_data, self.right_data)

--- a/src/bip/plugins/mikelima/IQ5_packet_data.py
+++ b/src/bip/plugins/mikelima/IQ5_packet_data.py
@@ -181,5 +181,7 @@ class Process_IQ5_Packet():
         self.AFS_mode = SOM_obj.AFS_mode
         self.SchedNum = SOM_obj.SchedNum
         self.SIinSchedNum = SOM_obj.SIinSchedNum
+
+        self.packet_id += 1
             
         self.__add_record(packet, self.left_data, self.right_data, self.center_data)

--- a/src/bip/plugins/mikelima/IQ5_packet_data.py
+++ b/src/bip/plugins/mikelima/IQ5_packet_data.py
@@ -180,13 +180,11 @@ class Process_IQ5_Packet():
         right before the next SOP or EOM
         '''
         self.sample_rate = 1280/(2**packet.Rx_config)
-        print(len(stream))
-        print(2*SOM_obj.Dwell*BEAMS*self.sample_rate)
         data = np.frombuffer(stream, 
                             offset=np.uint64(LANES*(MARKER_BYTES+HEADER_BYTES)),
                             count=np.uint64(2*SOM_obj.Dwell*BEAMS*self.sample_rate), 
                             dtype = np.int16).reshape((-1, 2))
-        print(len(data))
+
         self.left_data = data[::3]
         self.right_data = data[1::3]
         self.center_data = data[2::3]

--- a/src/bip/plugins/mikelima/parser.py
+++ b/src/bip/plugins/mikelima/parser.py
@@ -12,6 +12,7 @@ from . import header
 from . message_data import Process_Message
 from . import message_data
 from bip.non_vita import mblb
+import traceback
 
 MESSAGE_FILENAME="message_content"
 PACKET_FILENAME="packet_content"
@@ -61,7 +62,9 @@ class Parser:
         self._closed = False  
         
         if not data_recorder:
-            data_recorder = Recorder
+            self.data_recorder = Recorder
+        else:
+            self.data_recorder = data_recorder
 
     @property
     def metadata(self) -> dict:
@@ -89,7 +92,7 @@ class Parser:
         
         self.message_processor = Process_Message(
                 self._output_path,
-                self._recorder,
+                self.data_recorder,
                 options = self._recorder_options,
                 batch_size = 10,
                 IQ_type = IQ_type)
@@ -270,5 +273,6 @@ class Parser:
             try:
                 msg_words, SOM_obj = self.read_message(stream)
             except:
+                traceback.print_exc()
                 msg_words = None
       

--- a/src/bip/plugins/mikelima/parser.py
+++ b/src/bip/plugins/mikelima/parser.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import traceback
 
 import numpy as np
-import pyarrow as pa 
+import pyarrow as pa
 
 from bip import non_vita
 
@@ -16,8 +16,8 @@ import traceback
 
 MESSAGE_FILENAME="message_content"
 PACKET_FILENAME="packet_content"
-UNHANDLED_MARKERS = [bytes.fromhex('F37FFF7FFF7FFF7F'), 
-                    bytes.fromhex('F77FFF7FFF7FFF7F'), 
+UNHANDLED_MARKERS = [bytes.fromhex('F37FFF7FFF7FFF7F'),
+                    bytes.fromhex('F77FFF7FFF7FFF7F'),
                     bytes.fromhex('F87FFF7FFF7FFF7F'),
                     bytes.fromhex('F97FFF7FFF7FFF7F'),
                     bytes.fromhex('FA7FFF7FFF7FFF7F')]
@@ -46,7 +46,7 @@ class Parser:
         self._output_path = output_path
         self._recorder = Recorder
         self._recorder_options = recorder_opts
-        
+
 
         self.options = kwargs
         self._bytes_read = 0
@@ -59,10 +59,10 @@ class Parser:
         self._session_id = 0
         self._increment = 0
         self._timestamp_from_filename = 0
-        
+
         self._EOM_length = IQ0_EOM_BYTES
-        self._closed = False  
-        
+        self._closed = False
+
         if not data_recorder:
             self.data_recorder = Recorder
         else:
@@ -75,7 +75,7 @@ class Parser:
                 'version': version,
                 'options': self.options,
                 'messages_read': self._messages_read,
-        } 
+        }
 
     @property
     def bytes_read(self) -> int:
@@ -88,10 +88,10 @@ class Parser:
     @property
     def packets_read(self) -> int:
         return self._packets_read
-        
+
     def initialize_message_processor(self, IQ_type: int):
         message_data_filename = f"{MESSAGE_FILENAME}.{self._recorder.extension()}"
-        
+
         self.message_processor = Process_Message(
                 self._output_path,
                 self.data_recorder,
@@ -107,7 +107,7 @@ class Parser:
             schema= pa.schema([(e[0], e[1]) for e in message_data._message_schema]),
             options=self._recorder_options,
             batch_size=10)
-    
+
     def read_message(self, buf: RawIOBase):
         '''
         Take in 1 64-bit word at a time, looking for EOM marker
@@ -115,17 +115,17 @@ class Parser:
         Will raise exception if we encounter any of the unhandled markers
         '''
         header_data, bytes_read = header.read_message_header(buf) # Bytearray and integer
-        if bytes_read == 0: 
-            if self.message_recorder.writer != None: 
+        if bytes_read == 0:
+            if self.message_recorder.writer != None:
                 self.message_recorder.close()
-            return None
+            return None, None
 
         SOM_obj = mblb.mblb_SOM(header_data, self._timestamp, self._IQ_type, self._session_id, self._increment, self._timestamp_from_filename)
         self._message_key = SOM_obj.message_key
 
         message = bytearray(8)
         message_size = buf.readinto(message)
-        
+
         # Look for SOP not EOM
         # read packet size of packet
         while message[-8:] != bytes.fromhex('F27FFF7FFF7FFF7F'):
@@ -140,7 +140,7 @@ class Parser:
                     blank_end_of_message = bytearray(24*8)
                     blank_EOM_obj = mblb.mblb_EOM(blank_end_of_message)
                     self.__add_record(SOM_obj, blank_EOM_obj)
-        
+
                     self._bytes_read += bytes_read + message_size
                     return message[:-8], SOM_obj
                 SOP_obj = mblb.mblb_Packet(packet_header[16:(16+(LANES*HEADER_BYTES))])
@@ -157,16 +157,16 @@ class Parser:
                     blank_end_of_message = bytearray(self._EOM_length*8)
                     blank_EOM_obj = mblb.mblb_EOM(blank_end_of_message)
                     self.__add_record(SOM_obj, blank_EOM_obj)
-        
+
                     self._bytes_read += bytes_read + message_size
                     return message[:-8], SOM_obj
-                
+
                 message += packet_header + packet_data
                 message_size += header_length + data_length
 
             additional_message = bytearray(8)
             additional_message_length = buf.readinto(additional_message)
-           
+
             if additional_message in UNHANDLED_MARKERS:
                 raise Exception('This Bin file contains unhandled markers')
             if additional_message_length != 8:
@@ -174,13 +174,13 @@ class Parser:
                 blank_end_of_message = bytearray(self._EOM_length*8)
                 blank_EOM_obj = mblb.mblb_EOM(blank_end_of_message)
                 self.__add_record(SOM_obj, blank_EOM_obj)
-        
+
                 self._bytes_read += bytes_read + message_size
                 return message, SOM_obj
 
             message += additional_message
             message_size += additional_message_length
-            
+
         #Read the EOM markers for the other 2 lanes
         EOM_marker = bytearray(16)
         buf.readinto(EOM_marker)
@@ -191,10 +191,10 @@ class Parser:
         EOM_obj = mblb.mblb_EOM(end_of_message)
 
         self.__add_record(SOM_obj, EOM_obj)
-        
+
         self._bytes_read += bytes_read + message_size + 16 + (self._EOM_length*8)
         return message[:-8], SOM_obj
-    
+
     def __add_record(self,
             message: mblb.mblb_SOM,
             end: mblb.mblb_EOM
@@ -204,7 +204,7 @@ class Parser:
         '''
         assert isinstance(message, mblb.mblb_SOM)
         assert isinstance(end, mblb.mblb_EOM)
-    
+
         self.message_recorder.add_record({
             "IQ_type": np.uint8(message.IQ_type),
             "session_id": np.uint8(message.session_id),
@@ -253,21 +253,21 @@ class Parser:
         '''
         if progress_bar is not None:
             last_read = 0
-        
+
         num_bytes_read, orphan_packet_list, self._timestamp, self._IQ_type, self._session_id, self._increment, self._timestamp_from_filename = header.read_first_header(stream)
-        
+
         if self._IQ_type == 5:
             self._EOM_length = IQ5_EOM_BYTES
 
         self.initialize_message_processor(self._IQ_type)
-        
+
         self._bytes_read += num_bytes_read
-        
+
         orphan_packet_number = self.message_processor.process_orphan_packets(orphan_packet_list, self._IQ_type, self._session_id, self._increment, self._timestamp_from_filename)
-        
+
         msg_words, SOM_obj = self.read_message(stream) #bytearray of the whole message
         while msg_words:
-            
+
             num_packets = self.message_processor.process_msg(msg_words, SOM_obj) # break into packets
             self._messages_read += 1
             self._packets_read += num_packets
@@ -280,4 +280,4 @@ class Parser:
             except:
                 traceback.print_exc()
                 msg_words = None
-      
+

--- a/src/bip/plugins/tango/signal_data_packet.py
+++ b/src/bip/plugins/tango/signal_data_packet.py
@@ -35,9 +35,7 @@ _schema = [
     ("packet_index", pa.uint32()),
 
     ("samples_i", pa.list_(pa.int16(), -1)),
-    ("samples_q", pa.list_(pa.int16(), -1)),
-    
-    ("data_key", pa.string())
+    ("samples_q", pa.list_(pa.int16(), -1))
 ]
 
 def _schema_elt(e: tuple) -> dict:
@@ -80,7 +78,7 @@ class SignalData:
 
         self.recorder = Recorder(
                 output_path,
-                schema=pa.schema([(e[0], e[1]) for e in _schema]),
+                # schema=pa.schema([(e[0], e[1]) for e in _schema]),
                 options=recorder_opts,
                 batch_size=batch_size)
 
@@ -123,10 +121,8 @@ class SignalData:
             "packet_index": np.uint32(packet_index),
 
             "samples_i": packet.data[:,0],
-            "samples_q": packet.data[:,1],
-            
-            "data_key": packet.context_packet_key
-        })
+            "samples_q": packet.data[:,1]
+        }, dwell_key=packet.context_packet_key)
 
     def process(self,
             payload: bytes,

--- a/src/bip/recorder/dummy/dummywriter.py
+++ b/src/bip/recorder/dummy/dummywriter.py
@@ -11,7 +11,7 @@ class DummyWriter:
 
     def __init__(self,
             filename: Path,
-            schema: pa.schema,
+            schema: pa.schema = None,
             options: dict = {},
             batch_size: int = 1000
             ):

--- a/src/bip/recorder/dwell/dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/dwell_pqwriter.py
@@ -37,8 +37,6 @@ class DwellPQWriter:
         self._dirname = filename.with_suffix("")
         self._dirname.mkdir()
 
-        # self.sample_data_i = np.zeros(0, dtype=np.int16)
-        # self.sample_data_q = np.zeros(0, dtype=np.int16)
         self.sample_data_i = []
         self.sample_data_q = []
         self.written_keys = {}

--- a/src/bip/recorder/dwell/dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/dwell_pqwriter.py
@@ -1,0 +1,181 @@
+from pathlib import Path
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import numpy as np
+
+from dataclasses import dataclass
+
+class DwellFragment:
+    start_time : int
+    end_time : int
+    n_samples : int
+    data_key : int
+
+    samples_i : list[np.int16]
+    samples_q : list[np.int16]
+
+
+samples_schema = pa.schema([
+    ("samples_i", pa.int16()),
+    ("samples_q", pa.int16())
+])
+
+class DwellPQWriter:
+    @staticmethod
+    def extension() -> str:
+        return "parquet"
+    
+    def __init__(self,
+        filename:Path,
+        schema: pa.schema,
+        options: dict = {},
+        batch_size: int = 1000,
+    ):
+
+        self._filename = filename
+        self._schema = schema
+        self._options = options.copy()
+        self._closed = False
+
+        self.batch_size = batch_size
+        self.schema = schema
+
+        self.packet_data = []
+        self.sample_data_i = np.zeros(0, dtype=np.int16)
+        self.sample_data_q = np.zeros(0, dtype=np.int16)
+        self.dwell_metadata = []
+        self.written_keys = {}
+        self.current_index = 0
+        self.packet_writer = None
+        self.sample_writer = None
+        self.dwell_metadata_writer = None
+        self.last_packet_time = 0
+
+        self._current_local_key = None
+        self._current_sample_file = None
+
+        self._dirname = filename.with_suffix("")
+        self._dirname.mkdir()
+        self._data_packet_filename = self._dirname / "packet_metadata.parquet"
+        self._dwell_metadata_filename = self._dirname / "samples_metadata.parquet"
+
+    def _record(self, end_of_dwell:bool):
+        packet_df = pd.DataFrame(self.packet_data)
+        packet_table = pa.Table.from_pandas(packet_df)
+
+        dwell_df = pd.DataFrame(self.dwell_metadata)
+        dwell_table = pa.Table.from_pandas(dwell_df)
+
+        samples_df = pd.DataFrame(
+            {
+                "samples_i": self.sample_data_i,
+                "samples_q": self.sample_data_q
+            }
+        )
+        samples_table = pa.Table.from_pandas(samples_df)
+        try:
+            if self.packet_writer == None and self.packet_data:
+                self.packet_writer = pq.ParquetWriter(
+                    self._data_packet_filename, 
+                    pa.Schema.from_pandas(packet_df)
+                )
+
+            if self.dwell_metadata_writer == None and self.dwell_metadata:
+                self.dwell_metadata_writer = pq.ParquetWriter(
+                    self._dwell_metadata_filename,
+                    pa.Schema.from_pandas(dwell_df)
+                )
+
+            if self.sample_writer == None:
+                self.sample_writer = pq.ParquetWriter(
+                    self._current_sample_file,
+                    samples_schema
+                )
+
+            if self.packet_data:
+                self.packet_writer.write_table(packet_table)
+            if self.dwell_metadata:
+                self.dwell_metadata_writer.write_table(dwell_table)
+            
+            self.sample_writer.write_table(samples_table)
+
+            if end_of_dwell:
+                self.sample_writer.close()
+                self.sample_writer = None
+
+        except Exception as e:
+            print(f"Error writing to file: {e}, {self._dirname}")
+
+        # clear out written data
+        self.packet_data = []
+        self.dwell_metadata = []
+        self.sample_data_i = np.zeros(0, dtype=np.int16)
+        self.sample_data_q = np.zeros(0, dtype=np.int16)
+
+    def add_record(self, record: dict):
+        # temporary for now, this will only work for Juliet.
+        local_key = record["stream_id"]
+        
+        if local_key != self._current_local_key:
+            # This is sample data for a new dwell, so write out all the sample
+            # data for the current dwell before starting on this one. 
+            self._record(True)
+
+            # If we've written data for this local key before, then we'll have to 
+            # write the rest of the data to a new file. 
+            if not local_key in self.written_keys:
+                self.written_keys[local_key] = 0
+                suffix = "0"
+            else:
+                times_key_written = self.written_keys[local_key]
+                times_key_written += 1
+                suffix = str(times_key_written)
+                self.written_keys[local_key] = times_key_written
+
+            self._current_sample_file = self._dirname / f"{str(local_key)}-{suffix}.parquet"
+            self.dwell_metadata.append(
+                {
+                    "local_key":local_key,
+                    "filename":str(self._current_sample_file),
+                    "first_packet_index": record["packet_id"]
+                }
+            )
+
+            self._current_local_key = local_key
+
+        self.sample_data_i = np.concat([self.sample_data_i, record.pop("samples_i")])
+        self.sample_data_q = np.concat([self.sample_data_q, record.pop("samples_q")])
+        self.packet_data.append(record)
+
+        self.current_index += 1
+        if self.current_index == self.batch_size:
+            self._record(False)
+
+    def close(self):
+        if self._closed:
+            return
+        
+        if self.current_index != 0:
+            self._record()
+
+        self.packet_writer.close()
+        self.dwell_metadata_writer.close()
+
+        self._closed = True
+
+    @property
+    def metadata(self) -> dict:
+        return  {
+            "output": str(self._filename),
+            "options": self._options,
+            "batch_size": self.batch_size
+        }
+    
+    def __del__(self):
+        try:
+            if not self._closed:
+                self.close()
+        except:
+            pass

--- a/src/bip/recorder/dwell/dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/dwell_pqwriter.py
@@ -122,9 +122,6 @@ class DwellPQWriter:
 
             self._current_sample_file = self._dirname / f"{str(local_key)}-{suffix}.parquet"
 
-            # mikelima compatibility
-            # first_packet_index = record["packet_id"] if "packet_id" in record else record["packet_number"]
-
             self.dwell_metadata_writer.add_record(
                 {
                     "local_key":local_key,

--- a/src/bip/recorder/dwell/dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/dwell_pqwriter.py
@@ -125,7 +125,7 @@ class DwellPQWriter:
             self.dwell_metadata_writer.add_record(
                 {
                     "local_key":local_key,
-                    "filename":str(self._current_sample_file),
+                    "filename":self._current_sample_file.name,
                     "first_record_index": self.records_counted
                 }
             )

--- a/src/bip/recorder/dwell/dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/dwell_pqwriter.py
@@ -117,7 +117,7 @@ class DwellPQWriter:
     def add_record(self, record: dict):
         # temporary for now, this will only work for Juliet.
         local_key = record["stream_id"]
-
+        
         if local_key != self._current_local_key:
             # This is sample data for a new dwell, so write out all the sample
             # data for the current dwell before starting on this one. 

--- a/src/bip/recorder/dwell/dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/dwell_pqwriter.py
@@ -117,7 +117,7 @@ class DwellPQWriter:
     def add_record(self, record: dict):
         # temporary for now, this will only work for Juliet.
         local_key = record["stream_id"]
-        
+
         if local_key != self._current_local_key:
             # This is sample data for a new dwell, so write out all the sample
             # data for the current dwell before starting on this one. 
@@ -144,6 +144,12 @@ class DwellPQWriter:
             )
 
             self._current_local_key = local_key
+            # Current packet is part of a new dwell, so we don't have to check time here.
+            self.last_packet_time = 0
+        
+        # make sure we get packets ordered in time within each dwell
+        assert record["time"] > self.last_packet_time
+        self.last_packet_time = record["time"]
 
         self.sample_data_i = np.concat([self.sample_data_i, record.pop("samples_i")])
         self.sample_data_q = np.concat([self.sample_data_q, record.pop("samples_q")])
@@ -158,7 +164,7 @@ class DwellPQWriter:
             return
         
         if self.current_index != 0:
-            self._record()
+            self._record(True)
 
         self.packet_writer.close()
         self.dwell_metadata_writer.close()

--- a/src/bip/recorder/dwell/dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/dwell_pqwriter.py
@@ -117,7 +117,7 @@ class DwellPQWriter:
     def add_record(self, record: dict):
         # temporary for now, this will only work for Juliet.
         local_key = record["stream_id"]
-        
+
         if local_key != self._current_local_key:
             # This is sample data for a new dwell, so write out all the sample
             # data for the current dwell before starting on this one. 
@@ -144,15 +144,12 @@ class DwellPQWriter:
             )
 
             self._current_local_key = local_key
-<<<<<<< HEAD
             # Current packet is part of a new dwell, so we don't have to check time here.
             self.last_packet_time = 0
         
         # make sure we get packets ordered in time within each dwell
         assert record["time"] > self.last_packet_time
         self.last_packet_time = record["time"]
-=======
->>>>>>> f995bd72269c6e3064dce9efa6bd304e2f183c19
 
         self.sample_data_i = np.concat([self.sample_data_i, record.pop("samples_i")])
         self.sample_data_q = np.concat([self.sample_data_q, record.pop("samples_q")])
@@ -167,11 +164,7 @@ class DwellPQWriter:
             return
         
         if self.current_index != 0:
-<<<<<<< HEAD
             self._record(True)
-=======
-            self._record()
->>>>>>> f995bd72269c6e3064dce9efa6bd304e2f183c19
 
         self.packet_writer.close()
         self.dwell_metadata_writer.close()

--- a/src/bip/recorder/dwell/dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/dwell_pqwriter.py
@@ -135,6 +135,7 @@ class DwellPQWriter:
             self._current_local_key = local_key
             self.last_packet_time = 0
         
+        record["local_key"] = dwell_key
         self.last_packet_time = record["time"]
 
         heapq.heappush(self.sample_data_i, (record["time"], record.pop("samples_i")))

--- a/src/bip/recorder/dwell/mikelima_dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/mikelima_dwell_pqwriter.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import heapq 
+
+from ..parquet.pqwriter import PQWriter
+from .dwell_pqwriter import DwellPQWriter
+
+import numpy as np
+
+samples_schema = pa.schema([
+    ("samples_i", pa.int16()),
+    ("samples_q", pa.int16())
+])
+
+
+class MikelimaDwellPQWriter:
+    @staticmethod
+    def extension() -> str:
+        return "parquet"
+
+
+    def __init__(self,
+        filename:Path,
+        schema: pa.schema = None,
+        options: dict = {},
+        batch_size: int = 1000,
+    ):
+
+        self._filename = filename
+        self._schema = schema
+        self._options = options.copy()
+        self._closed = False
+        
+        self._dirname = filename.parent
+        
+        self.written_keys = {}
+        
+        self.sample_writer_left = DwellPQWriter(
+            self._dirname / "data_left",
+            options=self._options,
+            schema=schema,
+            batch_size=batch_size
+        )
+        self.sample_writer_right = DwellPQWriter(
+            self._dirname / "data_right",
+            options=self._options,
+            schema=schema,
+            batch_size=batch_size
+        )
+        self.sample_writer_center = DwellPQWriter(
+            self._dirname / "data_center",
+            options=self._options,
+            schema=schema,
+            batch_size=batch_size
+        )
+
+
+    def extract_sample_type(record, samples_mapping, unused_keys):
+        record = record.copy()
+
+        for unused_samples in unused_keys:
+            if unused_samples in record:
+                del record[unused_samples]
+        
+        for samples_old, samples_new in samples_mapping.items():
+            record[samples_new] = record[samples_old]
+            del record[samples_old]
+
+        return record
+
+
+    def add_record(self, record: dict, dwell_key: int = None):
+        # split record, which contains samples for left right and possibly 
+        # center sample types, into one record for each sample type.
+
+        left_samples_map = { 
+            "samples_i_left": "samples_i", 
+            "samples_q_left": "samples_q" 
+        }
+        right_samples_map = { 
+            "samples_i_right": "samples_i", 
+            "samples_q_right": "samples_q" 
+        }
+        center_samples_map = { 
+            "samples_i_center": "samples_i", 
+            "samples_q_center": "samples_q" 
+        }
+
+        # trust me, this works
+        dwell_key_total = record["packet_number"] * 3
+        dwell_key_left = dwell_key_total
+        dwell_key_right = dwell_key_total + 1
+        dwell_key_center = dwell_key_total + 2
+        
+        left_record = MikelimaDwellPQWriter.extract_sample_type(
+            record,
+            left_samples_map,
+            list(right_samples_map.keys()) + list(center_samples_map.keys()),
+        )
+        right_record = MikelimaDwellPQWriter.extract_sample_type(
+            record,
+            right_samples_map,
+            list(left_samples_map.keys()) + list(center_samples_map.keys()),
+        )
+
+        self.sample_writer_left.add_record(left_record, dwell_key=dwell_key_left)
+        self.sample_writer_right.add_record(right_record, dwell_key=dwell_key_right)
+
+        if "samples_i_center" in record:
+            center_record = MikelimaDwellPQWriter.extract_sample_type(
+                record,
+                center_samples_map,
+                list(left_samples_map.keys()) + list(left_samples_map.keys()),
+            )
+            self.sample_writer_center.add_record(center_record, dwell_key=dwell_key_center)
+
+
+    def close(self):
+        if self._closed:
+            return
+        
+        self.sample_writer_left.close()
+        self.sample_writer_right.close()
+        self.sample_writer_center.close()
+
+        self._closed = True
+
+
+    @property
+    def metadata(self) -> dict:
+        return  {
+            "output": str(self._filename),
+            "options": self._options,
+            "batch_size": self.batch_size
+        }
+
+
+    def __del__(self):
+        try:
+            if not self._closed:
+                self.close()
+        except:
+            pass

--- a/src/bip/recorder/dwell/mikelima_dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/mikelima_dwell_pqwriter.py
@@ -38,23 +38,26 @@ class MikelimaDwellPQWriter:
         self.written_keys = {}
         
         self.sample_writer_left = DwellPQWriter(
-            self._dirname / "data_left",
+            self._dirname / "data",
             options=self._options,
-            schema=schema,
+            # schema=schema,
             batch_size=batch_size
         )
         self.sample_writer_right = DwellPQWriter(
-            self._dirname / "data_right",
+            self._dirname / "data",
             options=self._options,
-            schema=schema,
+            # schema=schema,
             batch_size=batch_size
         )
         self.sample_writer_center = DwellPQWriter(
-            self._dirname / "data_center",
+            self._dirname / "data",
             options=self._options,
-            schema=schema,
+            # schema=schema,
             batch_size=batch_size
         )
+
+        self.batch_size = batch_size
+        self.record_count = 0
 
 
     def extract_sample_type(record, samples_mapping, unused_keys):
@@ -88,11 +91,10 @@ class MikelimaDwellPQWriter:
             "samples_q_center": "samples_q" 
         }
 
-        # trust me, this works
-        dwell_key_total = record["packet_number"] * 3
-        dwell_key_left = dwell_key_total
-        dwell_key_right = dwell_key_total + 1
-        dwell_key_center = dwell_key_total + 2
+        # this works, trust me
+        dwell_key_left = self.record_count * 3
+        dwell_key_right = self.record_count * 3 + 1
+        dwell_key_center = self.record_count * 3 + 2
         
         left_record = MikelimaDwellPQWriter.extract_sample_type(
             record,
@@ -115,6 +117,8 @@ class MikelimaDwellPQWriter:
                 list(left_samples_map.keys()) + list(left_samples_map.keys()),
             )
             self.sample_writer_center.add_record(center_record, dwell_key=dwell_key_center)
+
+        self.record_count += 1
 
 
     def close(self):

--- a/src/bip/recorder/dwell/mikelima_dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/mikelima_dwell_pqwriter.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-import heapq 
+import heapq
 
 from ..parquet.pqwriter import PQWriter
 from .dwell_pqwriter import DwellPQWriter
@@ -32,27 +32,24 @@ class MikelimaDwellPQWriter:
         self._schema = schema
         self._options = options.copy()
         self._closed = False
-        
+
         self._dirname = filename.parent
-        
+
         self.written_keys = {}
-        
+
         self.sample_writer_left = DwellPQWriter(
             self._dirname / "data",
             options=self._options,
-            # schema=schema,
             batch_size=batch_size
         )
         self.sample_writer_right = DwellPQWriter(
             self._dirname / "data",
             options=self._options,
-            # schema=schema,
             batch_size=batch_size
         )
         self.sample_writer_center = DwellPQWriter(
             self._dirname / "data",
             options=self._options,
-            # schema=schema,
             batch_size=batch_size
         )
 
@@ -66,7 +63,7 @@ class MikelimaDwellPQWriter:
         for unused_samples in unused_keys:
             if unused_samples in record:
                 del record[unused_samples]
-        
+
         for samples_old, samples_new in samples_mapping.items():
             record[samples_new] = record[samples_old]
             del record[samples_old]
@@ -75,37 +72,40 @@ class MikelimaDwellPQWriter:
 
 
     def add_record(self, record: dict, dwell_key: int = None):
-        # split record, which contains samples for left right and possibly 
+        # split record, which contains samples for left right and possibly
         # center sample types, into one record for each sample type.
 
-        left_samples_map = { 
-            "samples_i_left": "samples_i", 
-            "samples_q_left": "samples_q" 
+        left_samples_map = {
+            "samples_i_left": "samples_i",
+            "samples_q_left": "samples_q"
         }
-        right_samples_map = { 
-            "samples_i_right": "samples_i", 
-            "samples_q_right": "samples_q" 
+        right_samples_map = {
+            "samples_i_right": "samples_i",
+            "samples_q_right": "samples_q"
         }
-        center_samples_map = { 
-            "samples_i_center": "samples_i", 
-            "samples_q_center": "samples_q" 
+        center_samples_map = {
+            "samples_i_center": "samples_i",
+            "samples_q_center": "samples_q"
         }
 
         # this works, trust me
         dwell_key_left = self.record_count * 3
         dwell_key_right = self.record_count * 3 + 1
         dwell_key_center = self.record_count * 3 + 2
-        
+
         left_record = MikelimaDwellPQWriter.extract_sample_type(
             record,
             left_samples_map,
             list(right_samples_map.keys()) + list(center_samples_map.keys()),
         )
+        left_record["polarization"] = "left"
+
         right_record = MikelimaDwellPQWriter.extract_sample_type(
             record,
             right_samples_map,
             list(left_samples_map.keys()) + list(center_samples_map.keys()),
         )
+        right_record["polarization"] = "right"
 
         self.sample_writer_left.add_record(left_record, dwell_key=dwell_key_left)
         self.sample_writer_right.add_record(right_record, dwell_key=dwell_key_right)
@@ -114,8 +114,10 @@ class MikelimaDwellPQWriter:
             center_record = MikelimaDwellPQWriter.extract_sample_type(
                 record,
                 center_samples_map,
-                list(left_samples_map.keys()) + list(left_samples_map.keys()),
+                list(left_samples_map.keys()) + list(right_samples_map.keys()),
             )
+            center_record["polarization"] = "center"
+
             self.sample_writer_center.add_record(center_record, dwell_key=dwell_key_center)
 
         self.record_count += 1
@@ -124,7 +126,7 @@ class MikelimaDwellPQWriter:
     def close(self):
         if self._closed:
             return
-        
+
         self.sample_writer_left.close()
         self.sample_writer_right.close()
         self.sample_writer_center.close()

--- a/src/bip/recorder/dwell/mikelima_dwell_pqwriter.py
+++ b/src/bip/recorder/dwell/mikelima_dwell_pqwriter.py
@@ -37,17 +37,7 @@ class MikelimaDwellPQWriter:
 
         self.written_keys = {}
 
-        self.sample_writer_left = DwellPQWriter(
-            self._dirname / "data",
-            options=self._options,
-            batch_size=batch_size
-        )
-        self.sample_writer_right = DwellPQWriter(
-            self._dirname / "data",
-            options=self._options,
-            batch_size=batch_size
-        )
-        self.sample_writer_center = DwellPQWriter(
+        self.sample_writer_inner = DwellPQWriter(
             self._dirname / "data",
             options=self._options,
             batch_size=batch_size
@@ -107,8 +97,8 @@ class MikelimaDwellPQWriter:
         )
         right_record["polarization"] = "right"
 
-        self.sample_writer_left.add_record(left_record, dwell_key=dwell_key_left)
-        self.sample_writer_right.add_record(right_record, dwell_key=dwell_key_right)
+        self.sample_writer_inner.add_record(left_record, dwell_key=dwell_key_left)
+        self.sample_writer_inner.add_record(right_record, dwell_key=dwell_key_right)
 
         if "samples_i_center" in record:
             center_record = MikelimaDwellPQWriter.extract_sample_type(
@@ -118,7 +108,7 @@ class MikelimaDwellPQWriter:
             )
             center_record["polarization"] = "center"
 
-            self.sample_writer_center.add_record(center_record, dwell_key=dwell_key_center)
+            self.sample_writer_inner.add_record(center_record, dwell_key=dwell_key_center)
 
         self.record_count += 1
 
@@ -127,9 +117,7 @@ class MikelimaDwellPQWriter:
         if self._closed:
             return
 
-        self.sample_writer_left.close()
-        self.sample_writer_right.close()
-        self.sample_writer_center.close()
+        self.sample_writer_inner.close()
 
         self._closed = True
 

--- a/src/bip/recorder/parquet/pqwriter.py
+++ b/src/bip/recorder/parquet/pqwriter.py
@@ -13,10 +13,10 @@ class PQWriter:
 
     def __init__(self,
             filename: Path,
-            schema: pa.schema,
+            schema: pa.schema = None,
             options: dict = {},
             batch_size: int = 1000
-            ):
+        ):
 
         self._closed = False
 
@@ -37,6 +37,9 @@ class PQWriter:
     def _record(self):
         df = pd.DataFrame(self.data)
         table = pa.Table.from_pandas(df)
+        if not self.schema:
+            self.schema = pa.Schema.from_pandas(df)
+            
         try:
             if self.writer == None:
                 self.writer = pq.ParquetWriter(self._filename, self.schema, **self._options)

--- a/src/bip/recorder/parquet/pqwriter.py
+++ b/src/bip/recorder/parquet/pqwriter.py
@@ -39,7 +39,7 @@ class PQWriter:
         table = pa.Table.from_pandas(df)
         if not self.schema:
             self.schema = pa.Schema.from_pandas(df)
-            
+
         try:
             if self.writer == None:
                 self.writer = pq.ParquetWriter(self._filename, self.schema, **self._options)
@@ -50,7 +50,7 @@ class PQWriter:
         self.data = []
         self.current_index = 0
 
-    def add_record(self, record: dict):
+    def add_record(self, record: dict, dwell_key: int = None):
         assert self.current_index < self.batch_size
         self.data.append(record)
         self.current_index += 1

--- a/src/bip/recorder/recorder_protocol.py
+++ b/src/bip/recorder/recorder_protocol.py
@@ -7,7 +7,7 @@ import pyarrow as pa
 class Recorder(Protocol):
     def __init__(self,
             filename: Path,
-            schema: pa.Schema,
+            schema: pa.Schema=None,
             options: dict = {}
             ):
         pass
@@ -20,7 +20,7 @@ class Recorder(Protocol):
     def metadata(self) -> dict:
         pass
 
-    def add_record(self, record: dict):
+    def add_record(self, record: dict, dwell_key: int = None):
         pass
 
     def close(self):


### PR DESCRIPTION
`data/` folder contents:
```python
[
 '1724372995-0.parquet',
 '1724488963-0.parquet',
 '1724283907-0.parquet',
 '1724356099-0.parquet',
 '1724465411-0.parquet',
 '1724200707-0.parquet',
 '1724368387-0.parquet',
 '1724254723-0.parquet',
 '1724151043-0.parquet',
 '1724471043-0.parquet'
 ...,
 'packet_metadata.parquet',
 'samples_metadata.parquet'
 ]
 ```
 
 each `#-#.parquet` contains columns `samples_i` and `samples_q` which are 16 bit integers. This dataframe has `sample_count` rows per packet for each packet that was determined to be part of the same dwell. 

`packet_metadata.parquet` columns. This dataframe has one row per packet.

```python
[
    'packet_id', 
    'packet_size', 
    'packet_count', 
    'tsfd', 
    'tsid', 
    'indicators', 
    'packet_type', 
    'tsi', 
    'tsf0', 
    'tsf1', 
    'time', 
    'stream_id', 
    'classId0', 
    'classId1', 
    'sample_count', 
    'trailer', 
    'frame_index', 
    'packet_index'
]
```


Example `sample_metadata.parquet` output:
|    |   local_key | filename                         |   first_packet_index |
|---:|------------:|:---------------------------------|---------------------:|
|  0 |  1724143107 | output/data/1724143107-0.parquet |                    0 |
|  1 |  1724144387 | output/data/1724144387-0.parquet |                    9 |
|  2 |  1724145411 | output/data/1724145411-0.parquet |                  322 |
|  3 |  1724146691 | output/data/1724146691-0.parquet |                  635 |
|  4 |  1724147715 | output/data/1724147715-0.parquet |                  948 |

`local_key` is the `stream_id` for Juliet, which is used to match data packets to context packets within a session.