### PR TITLE
IQ5 has a different sized EOM block compared to IQ0.

### DIFF
--- a/src/bip/plugins/mikelima/IQ5_packet_data.py
+++ b/src/bip/plugins/mikelima/IQ5_packet_data.py
@@ -180,13 +180,10 @@ class Process_IQ5_Packet():
         right before the next SOP or EOM
         '''
         self.sample_rate = 1280/(2**packet.Rx_config)
-        print(len(stream))
-        print(2*SOM_obj.Dwell*BEAMS*self.sample_rate)
         data = np.frombuffer(stream, 
                             offset=np.uint64(LANES*(MARKER_BYTES+HEADER_BYTES)),
                             count=np.uint64(2*SOM_obj.Dwell*BEAMS*self.sample_rate), 
                             dtype = np.int16).reshape((-1, 2))
-        print(len(data))
         self.left_data = data[::3]
         self.right_data = data[1::3]
         self.center_data = data[2::3]

--- a/src/bip/plugins/mikelima/header.py
+++ b/src/bip/plugins/mikelima/header.py
@@ -8,7 +8,7 @@ def _SOM_search(b: bytes) -> int:
     exceptions raised are passed in read_SOM
     '''
     if len(b) == 0:
-        return None
+        raise RuntimeError("start not found")
     elif len(b) != 8:
         raise RuntimeError(f"incomplete read of SOM header")
     if b == bytes.fromhex('F07FFF7FFF7FFF7F'):
@@ -75,7 +75,7 @@ def unpack_SOM(header_bytes: bytes, stream: RawIOBase):
     buffer = stream.read(16)
     if buffer != bytes.fromhex('F07FFF7FFF7FFF7FF07FFF7FFF7FFF7F'):
         raise RuntimeError("unexpected SOM format")
-        
+
     # 3 lanes of 4 words plus 24 SDW is 36 8-byte words
     bytes_out = bytearray(36*8)
     

--- a/src/bip/plugins/mikelima/header.py
+++ b/src/bip/plugins/mikelima/header.py
@@ -8,7 +8,7 @@ def _SOM_search(b: bytes) -> int:
     exceptions raised are passed in read_SOM
     '''
     if len(b) == 0:
-        raise RuntimeError("start not found")
+        return None
     elif len(b) != 8:
         raise RuntimeError(f"incomplete read of SOM header")
     if b == bytes.fromhex('F07FFF7FFF7FFF7F'):

--- a/src/bip/plugins/mikelima/parser.py
+++ b/src/bip/plugins/mikelima/parser.py
@@ -23,7 +23,8 @@ UNHANDLED_MARKERS = [bytes.fromhex('F37FFF7FFF7FFF7F'),
 LANES = 3
 MARKER_BYTES = 8
 HEADER_BYTES = 32
-EOM_BYTES = 22
+IQ0_EOM_BYTES = 22
+IQ5_EOM_BYTES = 21
 
 class Parser:
     options: dict
@@ -57,7 +58,8 @@ class Parser:
         self._session_id = 0
         self._increment = 0
         self._timestamp_from_filename = 0
-
+        
+        self._EOM_length = IQ0_EOM_BYTES
         self._closed = False  
         
         if not data_recorder:
@@ -149,7 +151,7 @@ class Parser:
                 data_length = buf.readinto(packet_data)
                 if data_length != packet_size:
                     print('Message is broken in the packet data')
-                    blank_end_of_message = bytearray(EOM_BYTES*8)
+                    blank_end_of_message = bytearray(self._EOM_length*8)
                     blank_EOM_obj = mblb.mblb_EOM(blank_end_of_message)
                     self.__add_record(SOM_obj, blank_EOM_obj)
         
@@ -166,7 +168,7 @@ class Parser:
                 raise Exception('This Bin file contains unhandled markers')
             if additional_message_length != 8:
                 print('Message is broken no EOM found')
-                blank_end_of_message = bytearray(EOM_BYTES*8)
+                blank_end_of_message = bytearray(self._EOM_length*8)
                 blank_EOM_obj = mblb.mblb_EOM(blank_end_of_message)
                 self.__add_record(SOM_obj, blank_EOM_obj)
         
@@ -181,13 +183,13 @@ class Parser:
         buf.readinto(EOM_marker)
         assert EOM_marker == bytes.fromhex('F27FFF7FFF7FFF7FF27FFF7FFF7FFF7F')
         #EOM is 24 8-byte WORDS
-        end_of_message = bytearray(EOM_BYTES*8)
+        end_of_message = bytearray(self._EOM_length*8)
         buf.readinto(end_of_message)
         EOM_obj = mblb.mblb_EOM(end_of_message)
 
         self.__add_record(SOM_obj, EOM_obj)
         
-        self._bytes_read += bytes_read + message_size + 16 + (EOM_BYTES*8)
+        self._bytes_read += bytes_read + message_size + 16 + (self._EOM_length*8)
         return message[:-8], SOM_obj
     
     def __add_record(self,
@@ -251,6 +253,9 @@ class Parser:
         
         num_bytes_read, orphan_packet_list, self._timestamp, self._IQ_type, self._session_id, self._increment, self._timestamp_from_filename = header.read_first_header(stream)
         
+        if self._IQ_type == 5:
+            self._EOM_length = IQ5_EOM_BYTES
+
         self.initialize_message_processor(self._IQ_type)
         
         self._bytes_read += num_bytes_read


### PR DESCRIPTION
When we read in the first IQ5 message we're including the first word of the next message's header. This causes the header check of the next message to fail. 

This MR should fix that issue