### PR TITLE
use numba for faster simple functions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     pandas
     pyarrow==17.0.0
     tqdm
+    numba
 include_package_data = False
 
 [options.packages.find]

--- a/src/bip/common/bit_manipulation.py
+++ b/src/bip/common/bit_manipulation.py
@@ -1,31 +1,37 @@
-import ctypes
 import numpy as np
+import numba
 
 """ common value extractions that multiple parsers can implement.
-    do consider the payload endianness, and if/when it may be 
+    do consider the payload endianness, and if/when it may be
     converted when using these, little endian is currently assumed """
 
 #Current Juliet Implementations
+@numba.jit(nopython=True)
 def bandwidth(word1, word2):
     raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
-    return np.float64(raw_data * (10**-6) * (2**-20)) 
+    return np.float64(raw_data * (10**-6) * (2**-20))
 
+@numba.jit(nopython=True)
 def dwell(word1, word2):
     raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
     # data comes in femtoseconds -9 converts to microseconds
-    return np.float64(raw_data * (10**-9))  
+    return np.float64(raw_data * (10**-9))
 
+@numba.jit(nopython=True)
 def frequency(word1, word2):
     raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
     return np.float64(raw_data * (10**-9) * (2**-20))
 
+@numba.jit(nopython=True)
 def gain(word1): # needs work, but not implemented in juliet yet
     return word1
 
+@numba.jit(nopython=True)
 def offset(word1, word2):
     raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
     return np.float64(raw_data * (10**-6) * (2**-20))
 
+@numba.jit(nopython=True)
 def pointing_vector(word):
     el = (word >> 16)
     if el >= 0x8000: #sign bit present, take 2's complement
@@ -34,17 +40,19 @@ def pointing_vector(word):
         el_out = el_out * (2**-7)
     else:
         el_out = el * (2**-7)
-    
+
     az = (word & 0xFFFF) * (2**-7)
     if az >= 280:
         az = az - 360
-        
+
     return az, el_out
 
+@numba.jit(nopython=True)
 def sample_rate(word1, word2):
     raw_data = (np.uint64(word1) << 32) | np.uint64(word2)
-    return np.uint32(raw_data * (10**-6) * (2**-20)) 
+    return np.uint32(raw_data * (10**-6) * (2**-20))
 
+@numba.jit(nopython=True)
 def time(tsi, tsf0, tsf1):
     return np.float64(np.uint64(tsi) +\
                     ((np.uint64(tsf0) << 32) + np.uint64(tsf1)) * (10**-12))

--- a/src/bip/common/numpy_manipulation.py
+++ b/src/bip/common/numpy_manipulation.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numba
 
 def rolling_window(array, window):
     shape = array.shape[:-1] + (array.shape[-1] - window + 1, window)
@@ -6,7 +7,39 @@ def rolling_window(array, window):
     return np.lib.stride_tricks.as_strided(array, shape=shape, strides=strides)
 
 
-def find_subarray_indexes(array, subarray):
+def find_subarray_indexes_numpy(array, subarray):
+    """
+    Finds all starting indexes where `array` equals `subarray`.
+    """
     temp = rolling_window(array, len(subarray))
     result = np.where(np.all(temp == subarray, axis=1))
     return result[0] if result else None
+
+@numba.jit(nopython=True)
+def find_subarray_indexes_numba(array, subarray):
+    """
+    Finds all starting indexes where `array` equals `subarray`.
+    """
+    array_idx = 0
+    match_length = 0
+    sub_len = len(subarray)
+    array_len = len(array)
+    stop = array_len - sub_len
+    indexes = []
+
+    while array_idx < array_len:
+        match_length = 0
+        while match_length < sub_len and array_idx + match_length < array_len and array[array_idx + match_length] == subarray[match_length]:
+            match_length += 1
+
+        if match_length == sub_len:
+            indexes.append(array_idx)
+
+        array_idx += 1
+
+    if len(indexes) > 0:
+        return np.array(indexes)
+
+    return None
+
+find_subarray_indexes = find_subarray_indexes_numba

--- a/src/bip/common/numpy_manipulation.py
+++ b/src/bip/common/numpy_manipulation.py
@@ -4,8 +4,8 @@ def rolling_window(array, window):
     shape = array.shape[:-1] + (array.shape[-1] - window + 1, window)
     strides = array.strides + (array.strides[-1],)
     return np.lib.stride_tricks.as_strided(array, shape=shape, strides=strides)
-    
-           
+
+
 def find_subarray_indexes(array, subarray):
     temp = rolling_window(array, len(subarray))
     result = np.where(np.all(temp == subarray, axis=1))

--- a/src/bip/plugins/juliet/data_context_packet.py
+++ b/src/bip/plugins/juliet/data_context_packet.py
@@ -1,4 +1,3 @@
-import struct
 from pathlib import Path
 
 import pyarrow as pa
@@ -77,10 +76,10 @@ class _DataContextPacket(VitaExtensionCommandPacket):
         # Jan 1 2019 we need to add 1546300800 to bring it inline with Unix
         self.time = (bit_manipulation.time(tsi, tsf0, tsf1) + 1546300800)
         self.classId0, self.classId1 = self.class_identifier
-        
+
         #missing cam from ICD, should be words[7]
         #missing messageId from ICD, should be words[8]
-        
+
         self.cif0 = self.words[7] #pick up at words[7], data matches this
         self.cif1 = self.words[8]
         self.cif2 = self.words[9]
@@ -96,7 +95,7 @@ class _DataContextPacket(VitaExtensionCommandPacket):
         self.polarization = self.words[23]
         self.azimuth, self.elevation = bit_manipulation.pointing_vector(self.words[24]) #does not follow ICD, this byte position comes from their matlab script
         self.beamWidth = self.words[25]
-        self.cited_SID = self.words[26] 
+        self.cited_SID = self.words[26]
         self.functionPriorityId = self.words[27]
         self.dwell = bit_manipulation.dwell(self.words[28], self.words[29]) # does not follow ICD, this byte position comes from ther matlab script
         self.requested_input_GT = self.words[30]
@@ -129,7 +128,7 @@ class DataContext:
             ):
         assert isinstance(packet, _DataContextPacket)
         header = packet.packet_header
-    
+
 
         self.recorder.add_record({
             "packet_id": np.uint32(self.packet_id),

--- a/src/bip/recorder/parquet/pqwriter.py
+++ b/src/bip/recorder/parquet/pqwriter.py
@@ -29,7 +29,7 @@ class PQWriter:
         self.data = []
         self.writer = None
         self.current_index = 0
-        
+
         # terrible, horrible, no good, very bad hack.
         if "partition_cols" in self._options:
             del self._options['partition_cols']


### PR DESCRIPTION
Juliet stream 0 files are 25-30% faster to parse after the bit_manipulation changes. Juliet data files were not significantly faster or slower.
MikeLima files (both IQ0 and IQ5) were about 50% faster to parse after the numpy_manipulation changes.
Tango was not significantly affected.

All benchmarks run on my gov laptop.