### PR TITLE
Making IQ_type's type consistent in both the message_data and the packet_data

### DIFF
--- a/src/bip/plugins/mikelima/IQ0_packet_data.py
+++ b/src/bip/plugins/mikelima/IQ0_packet_data.py
@@ -11,7 +11,7 @@ MARKER_BYTES = 8
 HEADER_BYTES = 32
 
 _IQ0_packet_schema = [
-    ("IQ_type", pa.float32()),
+    ("IQ_type", pa.uint8()),
     ("session_id", pa.uint8()),
     ("increment", pa.uint32()),
     ("timestamp_from_filename", pa.uint64()),
@@ -98,7 +98,7 @@ class Process_IQ0_Packet():
         assert isinstance(packet, mblb.mblb_Packet)
     
         self.packet_recorder.add_record({
-            "IQ_type": np.float32(self.IQ_type),
+            "IQ_type": np.uint8(self.IQ_type),
             "session_id": np.uint8(self.session_id),
             "increment": np.uint32(self.increment),
             "timestamp_from_filename": np.uint64(self.timestamp_from_filename),

--- a/src/bip/plugins/mikelima/IQ5_packet_data.py
+++ b/src/bip/plugins/mikelima/IQ5_packet_data.py
@@ -11,7 +11,7 @@ MARKER_BYTES = 8
 HEADER_BYTES = 32
 
 _IQ5_packet_schema = [
-    ("IQ_type", pa.float32()),
+    ("IQ_type", pa.uint8()),
     ("session_id", pa.uint8()),
     ("increment", pa.uint32()),
     ("timestamp_from_filename", pa.uint64()),
@@ -101,7 +101,7 @@ class Process_IQ5_Packet():
         assert isinstance(packet, mblb.mblb_Packet)
     
         self.packet_recorder.add_record({
-            "IQ_type": np.float32(self.IQ_type),
+            "IQ_type": np.uint8(self.IQ_type),
             "session_id": np.uint8(self.session_id),
             "increment": np.uint32(self.increment),
             "timestamp_from_filename": np.uint64(self.timestamp_from_filename),


### PR DESCRIPTION
Currently IQ_type is stored as a uint8 in the message_data and as a float32 in the packet_data.
This causes an inconsistency during the bip_parse pipeline step when we combine the message_data and packet_data together and drop the multiple columns.
It is unclear which column pandas drops, so to avoid the inconsistency the IQ_type type has been changed to be consistent